### PR TITLE
Create CI tests using github workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,49 @@
+name: libmetal Continuous Integration
+
+on:
+  push:
+    branches: [ master ]
+    paths-ignore:
+      - docs/**
+      - cmake/**
+      - scripts/**
+  pull_request:
+    branches: [ master ]
+    paths-ignore:
+      - docs/**
+      - cmake/**
+      - scripts/**
+
+jobs:
+  nr_tests:
+    name: nonreg tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: configure
+      run: |
+        sudo apt-get update && sudo apt-get install libsysfs-dev
+        cmake . -Bbuild
+    - name: build
+      run: |
+        cd build
+        make
+    - name: execute test
+      run: |
+        cd build
+        make test
+    - name: test logs
+      if: failure()
+      run: |
+        cat build/Testing/Temporary/LastTest.log
+        exit 1
+
+  checkpatch_review:
+    name: checkpatch review
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Run checkpatch review
+      uses: webispy/checkpatch-action@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Create a first series of tests for continuous integration
- run non regression test for Linux system
- run checkpatch action from
  https://github.com/webispy/checkpatch-action

Signed-off-by: Arnaud Pouliquen <arnaud.pouliquen@st.com>