### PR TITLE
test: zephyr: fix 'errno' undeclared

### DIFF
--- a/test/system/zephyr/alloc.c
+++ b/test/system/zephyr/alloc.c
@@ -7,6 +7,7 @@
 #include <stdlib.h>
 
 #include <metal/alloc.h>
+#include <metal/errno.h>
 #include <metal/log.h>
 #include <metal/sys.h>
 #include <sys/printk.h>
@@ -19,7 +20,7 @@ static int alloc(void)
 	ptr = metal_allocate_memory(1000);
 	if (!ptr) {
 		metal_log(METAL_LOG_DEBUG, "failed to allocate memmory\n");
-		return errno;
+		return -errno;
 	}
 
 	metal_free_memory(ptr);


### PR DESCRIPTION
The return value should be negative.
Add include of errno.h to avoid unresolved symbol error when link the
test.

Signed-off-by: Arnaud Pouliquen <arnaud.pouliquen@foss.st.com>