### PR TITLE
lib: fix compilation error with gcc++

### DIFF
--- a/cmake/syscheck.cmake
+++ b/cmake/syscheck.cmake
@@ -10,5 +10,8 @@ if (WITH_ZEPHYR)
   if (CONFIG_ARM)
     set (MACHINE "arm" CACHE STRING "")
   endif(CONFIG_ARM)
+  if (CONFIG_RISCV)
+    set (MACHINE "riscv" CACHE STRING "")
+  endif (CONFIG_RISCV)
 
 endif (WITH_ZEPHYR)

--- a/lib/system/zephyr/riscv/CMakeLists.txt
+++ b/lib/system/zephyr/riscv/CMakeLists.txt
@@ -1,0 +1,2 @@
+collect (PROJECT_LIB_HEADERS sys.h)
+collect (PROJECT_LIB_SOURCES sys.c)

--- a/lib/system/zephyr/riscv/sys.c
+++ b/lib/system/zephyr/riscv/sys.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * @file	zephyr/riscv/sys.c
+ * @brief	machine specific system primitives implementation.
+ */
+
+#include <metal/io.h>
+#include <metal/sys.h>
+#include <stdint.h>
+
+/**
+ * @brief poll function until some event happens
+ */
+void metal_weak metal_generic_default_poll(void)
+{
+	metal_asm __volatile__("wfi");
+}

--- a/lib/system/zephyr/riscv/sys.h
+++ b/lib/system/zephyr/riscv/sys.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * @file	zephyr/riscv/sys.h
+ * @brief	Zephyr riscv system primitives for libmetal.
+ */
+
+#ifndef __METAL_ZEPHYR_SYS__H__
+#error "Include metal/sys.h instead of metal/generic/@PROJECT_MACHINE@/sys.h"
+#endif
+
+#ifndef __METAL_ZEPHYR_RISCV_SYS__H__
+#define __METAL_ZEPHYR_RISCV_SYS__H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __METAL_ZEPHYR_RISCV_SYS__H__ */


### PR DESCRIPTION
The header files including must be outside of the extern "C" { statement.
To be able to be included from C++ code.

Else such error can occur (reproduce on STM32MP1Cube distribution)
gcc/arm-none-eabi/include/c++/10.2.1/atomic:1467:3: error: template
with C linkage
 1467 |   template<typename _ITp>
      |   ^~~~~~~~
In file included from STM32CubeMP1/Middlewares/Third_Party/OpenAMP/
                      open-amp/lib/include/openamp/rpmsg.h:16,
                 from STM32CubeMP1/Middlewares/Third_Party/OpenAMP/
                      open-amp/lib/include/openamp/open_amp.h:11,
                 from empty_main.cpp:1:
STM32CubeMP1/Middlewares/Third_Party/OpenAMP/libmetal/lib/include/
metal/mutex.h:16:1: note: 'extern "C"' linkage
started here
   16 | extern "C" {
      | ^~~~~~~~~~

Signed-off-by: Arnaud Pouliquen <arnaud.pouliquen@foss.st.com>