### PR TITLE
test: Zephyr: Replace k_mem_block usage

### DIFF
--- a/test/system/zephyr/main.c
+++ b/test/system/zephyr/main.c
@@ -16,7 +16,7 @@
 #define BLK_NUM_MAX 16
 
 K_HEAP_DEFINE(kmpool, BLK_SIZE_MAX * BLK_NUM_MAX);
-struct k_mem_block block[BLK_NUM_MAX];
+void *block[BLK_NUM_MAX];
 
 extern int init_system(void);
 extern void metal_generic_default_poll(void);
@@ -29,15 +29,15 @@ extern void metal_test_add_mutex();
 extern void *metal_zephyr_allocate_memory(unsigned int size)
 {
 	int i;
-	struct k_mem_block *blk;
+	void **blk;
 
 	for (i = 0; i < sizeof(block)/sizeof(block[0]); i++) {
 		blk = &block[i];
-		if (!blk->data) {
-			blk->data = k_heap_alloc(&kmpool, size, K_NO_WAIT);
-			if (!blk->data)
+		if (!blk) {
+			*blk = k_heap_alloc(&kmpool, size, K_NO_WAIT);
+			if (!*blk)
 				printk("Failed to alloc 0x%x memory.\n", size);
-			return blk->data;
+			return *blk;
 		}
 	}
 
@@ -48,13 +48,13 @@ extern void *metal_zephyr_allocate_memory(unsigned int size)
 extern void metal_zephyr_free_memory(void *ptr)
 {
 	int i;
-	struct k_mem_block *blk;
+	void **blk;
 
 	for (i = 0; i < sizeof(block)/sizeof(block[0]); i++) {
 		blk = &block[i];
-		if (blk->data == ptr) {
-			k_heap_free(&kmpool, blk);
-			blk->data = NULL;
+		if (*blk == ptr) {
+			k_heap_free(&kmpool, *blk);
+			*blk = NULL;
 			return;
 		}
 	}


### PR DESCRIPTION
The k_mem_block structure is obsolete for some years replace it by a "void *" pointer. as done in Zephyr.