### PR TITLE
CI: Fix Zephyr build by updating Zephyr SDK version to 0.17.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,8 @@
 cmake_minimum_required (VERSION 3.0.2)
-
-#added in cmake v3.0
 if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
 endif()
 
-
-#added in cmake v3.1
-if (POLICY CMP0053)
-  cmake_policy(SET CMP0053 NEW)
-endif()
-
-#added in cmake v3.13
 if (POLICY CMP0077)
   cmake_policy(SET CMP0077 NEW)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,17 @@
 cmake_minimum_required (VERSION 3.0.2)
+
+#added in cmake v3.0
 if (POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
 endif()
 
+
+#added in cmake v3.1
+if (POLICY CMP0053)
+  cmake_policy(SET CMP0053 NEW)
+endif()
+
+#added in cmake v3.13
 if (POLICY CMP0077)
   cmake_policy(SET CMP0077 NEW)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,4 @@
-cmake_minimum_required (VERSION 3.0.2)
-if (POLICY CMP0048)
-  cmake_policy(SET CMP0048 NEW)
-endif()
-
-if (POLICY CMP0077)
-  cmake_policy(SET CMP0077 NEW)
-endif()
+cmake_minimum_required (VERSION 3.16)
 
 set (LIBMETAL_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 


### PR DESCRIPTION
Update zephyr SDK to 0.17.0 to fix CI build issue:

CMake Error at zephyrproject/zephyr/cmake/modules/version.cmake:66 (string):
  Syntax error in cmake code at

  /github/workspace/zephyrproject/zephyr/cmake/modules/version.cmake:66

  when parsing string

   EXTRAVERSION = ([a-z0-9\.\-]*)